### PR TITLE
close the netlink connections on errors

### DIFF
--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -266,10 +266,5 @@ func (h *Handles) sendMessage(hdr *syscall.NlMsghdr, data []byte) error {
 		Data:   data,
 	}
 
-	err = sh.query(netlinkMsg)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return sh.query(netlinkMsg)
 }

--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -256,6 +256,7 @@ func (h *Handles) SendMessage(hdr *syscall.NlMsghdr, data []byte) error {
 
 func (h *Handles) sendMessage(hdr *syscall.NlMsghdr, data []byte) error {
 	sh, err := h.open()
+	defer sh.close()
 	if err != nil {
 		return err
 	}
@@ -270,6 +271,5 @@ func (h *Handles) sendMessage(hdr *syscall.NlMsghdr, data []byte) error {
 		return err
 	}
 
-	sh.close()
 	return nil
 }


### PR DESCRIPTION
The netlink socket is not closed in case of errors. This could exhaust # of open files in the system/user during conntrack failures. This PR fixes that.
